### PR TITLE
Fix documentation names on Windows

### DIFF
--- a/src/js/writter.js
+++ b/src/js/writter.js
@@ -91,7 +91,7 @@ function processDoc(config){
                 'toc' : parseResult.toc
             });
 
-            var relativeRoot = path.relative( fileInfo.output.replace(/\/[^\/]+$/, '/'), config.outputDir );
+            var relativeRoot = path.relative( fileInfo.output.replace(/[\/\\][^\/\\]+$/, '/'), config.outputDir );
 
             return _docTemplate({
                 root_path : relativeRoot? relativeRoot +'/' : '',


### PR DESCRIPTION
On Windows the documentation pages would all have titles like `\mydoc` and links like `\mydoc.html`. This PR fixes this issue.
