### PR TITLE
Removes backslashes from sidebar title

### DIFF
--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -54,7 +54,7 @@ function getTocData(mdown){
         matchName = rName.exec(matchTitle[1]);
         toc.push({
            href : matchName[1],
-           title : matchTitle[1],
+           title : matchTitle[1].replace(/\\/g, ''),
            name : (matchName.slice(1,4).join('')),
            description : getDescription(mdown, rH.lastIndex)
         });


### PR DESCRIPTION
I just removed any backslash from the `title` property used by the sidebar menu, it successfully fixed my problems and I tested it enough to be sure it doesn't break anything else

Anyways, take a look, it shouldn't be long to review the changes.
