### PR TITLE
pre code preserves new lines and causes excessive spacing.

### DIFF
--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -24,7 +24,7 @@ exports.parseMdown = function(mdown){
 
 
 function wrapCode(str, p1, p2){
-    return p1? '<pre class="brush:'+ p1 +'">\n'+ p2 +'</pre>' : '<pre>\n'+ p2 +'</pre>';
+    return p1? '<pre class="brush:'+p1+'">'+p2+'</pre>' : '<pre>'+p2+'</pre>';
 }
 
 function convertCodeBlocks(mdown){


### PR DESCRIPTION
CSS should handle that spacing instead. Output the actual code into the pre tag and let CSS margins, padding or even ::before/::after handle the code spacing, not spacing in the HTML that can't be removed without JS
