### PR TITLE
Fix click on the toggling triangle in the sidebar index entry

### DIFF
--- a/src/template/assets_/css/main.css
+++ b/src/template/assets_/css/main.css
@@ -563,7 +563,7 @@ hr {
     cursor:pointer;
 }
 
-.toc-mod-title.collapsible a:before {
+.toc-mod-title.collapsible .toc-mod-toggle:before {
     content: '';
     width: 0;
     height: 0;
@@ -574,7 +574,7 @@ hr {
     margin: 0.3em 0.5em 0 0;
 }
 
-.toc-mod-title.collapsible.opened a:before {
+.toc-mod-title.collapsible.opened .toc-mod-toggle:before {
     border-top: 0.3em solid #999;
     border-right: 0.3em solid transparent;
     border-left: 0.3em solid transparent;

--- a/src/template/assets_/css/main.css
+++ b/src/template/assets_/css/main.css
@@ -553,13 +553,14 @@ hr {
 
 .toc-mod-title {
     margin: 0;
-    padding: 0.5em;
+    padding: 0.5em 0.5em 0.5em 1.2em;
     font-size: 1.3em;
     background-color: #eee;
     outline:1px solid #ddd;
 }
 
 .toc-mod-title.collapsible {
+    padding: 0.5em;
     cursor:pointer;
 }
 

--- a/src/template/sidebar.hbs
+++ b/src/template/sidebar.hbs
@@ -5,7 +5,10 @@
 <div class="bd">
     <div class="toc">
         {{#modules}}
-            <h3 class="toc-mod-title"><a href="{{file}}">{{module}}</a></h3>
+            <h3 class="toc-mod-title">
+                <span class="toc-mod-toggle"></span>
+                <a href="{{file}}">{{module}}</a>
+            </h3>
             <div class="toc-list">
                 {{#toc}}
                 <a class="toc-item" href="{{../file}}#{{href}}">


### PR DESCRIPTION
Suggested fix for #36 (Clicking on the toggling triangle in the sidebar index entry navigates to the article).