### PR TITLE
Extend handlebars context

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -172,6 +172,36 @@ hbHelpers : {
 }
 ```
 
+#### Handlebars context
+
+You can also extend the context that gets provided to the Handlebars templates.
+
+```js
+ctx : {
+  menu: [
+    { name: 'Home', link: '/'},
+    { name: 'Documentation', link: '/docs'},
+    { name: 'API', link: '/docs/api'}
+  ],
+  site: {
+    page: {
+      title: 'API Documentation'
+    }
+  }
+}
+```
+
+Those could be used inside your custom template as follow
+
+```html
+<ul>
+{{#each ctx.menu}}
+  <li><a href="{{link}}">{{name}}</a></li>
+{{/each}}
+</ul>
+
+<h2>{{ ctx.site.page.title }}</h2>
+```
 
 ## Examples
 

--- a/src/js/writter.js
+++ b/src/js/writter.js
@@ -59,14 +59,16 @@ exports.processFiles = function(config){
 
     console.log('  Generating Sidebar...');
     fs.writeFileSync(path.join(outputDir, 'sidebar_.html'), _sidebarTemplate({
-        modules : toc
+        modules : toc,
+        ctx: config.ctx || {}
     }), 'utf-8');
 
     console.log('  Generating Index...');
     fs.writeFileSync(path.join(outputDir, 'index.html'), _indexTemplate({
         modules : toc,
         page_title : config.baseTitle || DEFAULT_PAGE_TITLE,
-        content : getIndexContent(config)
+        content : getIndexContent(config),
+        ctx: config.ctx || {}
     }), 'utf-8');
 
     console.log('  Copying Assets...');
@@ -103,7 +105,8 @@ function processDoc(config){
             return _docTemplate({
                 root_path : relativeRoot? relativeRoot +'/' : '',
                 content : parseResult.html,
-                page_title : parseResult.title +' : '+ (config.baseTitle || DEFAULT_PAGE_TITLE)
+                page_title : parseResult.title +' : '+ (config.baseTitle || DEFAULT_PAGE_TITLE),
+                ctx: config.ctx || {}
             });
         });
         console.log('  processed: '+ fileInfo.input +' > '+ fileInfo.output);


### PR DESCRIPTION
This allow the user to provide a custom context to the templates.

closes #38 