### PR TITLE
Added field "title" to mapTocName callback.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -121,7 +121,7 @@ mapOutName: function (outputName) {
 Change the name displayed on the sidebar and on the index TOC
 
 ```javascript
-mapTocName: function (fileName, tocObject) {
+mapTocName: function (fileName, tocObject, title) {
  return fileName.replace('_doc.html', '');
 }
 ```

--- a/src/js/writter.js
+++ b/src/js/writter.js
@@ -92,7 +92,7 @@ function processDoc(config){
         pathProcessor.processFile(fileInfo, function(content){
             var parseResult = parser.parseDoc(content, config.headingLevel),
                 fileName = fileInfo.output.replace(config.outputDir, '').replace(/^[\/\\]/, ''),
-                moduleName = config.mapTocName? config.mapTocName(fileName, parseResult.toc) : fileName.replace('.html', '');
+                moduleName = config.mapTocName? config.mapTocName(fileName, parseResult.toc, parseResult.title) : fileName.replace('.html', '');
 
             toc.push({
                 'file' : fileName,


### PR DESCRIPTION
This change allows to naming articles by context instead of using just filename. This is extremely useful for non-english articles which titles often cannot be stored in filename.