### PR TITLE
Using handlebars compilation for content (markdown files).

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -178,6 +178,7 @@ You can also extend the context that gets provided to the Handlebars templates.
 
 ```js
 ctx : {
+  version: '1.0.0'
   menu: [
     { name: 'Home', link: '/'},
     { name: 'Documentation', link: '/docs'},
@@ -201,6 +202,14 @@ Those could be used inside your custom template as follow
 </ul>
 
 <h2>{{ ctx.site.page.title }}</h2>
+```
+
+Also you can use Handlebars template in your markdown files:
+
+```
+## {{ ctx.site.page.title }}
+
+Current version: {{ ctx.version }}
 ```
 
 ## Examples

--- a/src/js/writter.js
+++ b/src/js/writter.js
@@ -104,7 +104,7 @@ function processDoc(config){
 
             return _docTemplate({
                 root_path : relativeRoot? relativeRoot +'/' : '',
-                content : parseResult.html,
+                content : handlebars.compile(parseResult.html)({ctx: config.ctx}),
                 page_title : parseResult.title +' : '+ (config.baseTitle || DEFAULT_PAGE_TITLE),
                 ctx: config.ctx || {}
             });
@@ -144,7 +144,7 @@ function generateFile(toc, template, outputFile, title){
 
 function getIndexContent(config){
     if (config.indexContentPath && !config.indexContent) {
-        config.indexContent = parser.parseMdown( fs.readFileSync(config.indexContentPath, 'utf-8') );
+        config.indexContent = handlebars.compile(parser.parseMdown( fs.readFileSync(config.indexContentPath, 'utf-8') ))({ctx: config.ctx});
     }
     return config.indexContent || '';
 }


### PR DESCRIPTION
Now you can use Handlebars in your markdown files - it will be compiled after markdown compilation. It is useful if you have variable parts in your docs (like links, version number, etc).