### PR TITLE
Parser override

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -212,6 +212,16 @@ Also you can use Handlebars template in your markdown files:
 Current version: {{ ctx.version }}
 ```
 
+#### Parser override
+
+If you want to use another markdown parser you can override the parsing function:
+
+```javascript
+parsingFunction: function(markdownText): {
+	return myParser.markdownToHtml(markdownText);
+}
+```
+
 ## Examples
 
 For a live example check: [MOUT documentation](http://moutjs.com/docs/latest/)

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -4,8 +4,12 @@ var showdown = require('showdown');
 var Parser = function(config) {
     this.config = config;
     this.headingLevel = config.headingLevel || 2;
-    var converter = new showdown.Converter();
-    this.parseMdown = converter.makeHtml;
+    if (config.parsingFunction) {
+        this.parseMdown = config.parsingFunction;
+    } else {
+        var converter = new showdown.Converter();
+        this.parseMdown = converter.makeHtml;
+    }
 }
 
 Parser.prototype.parseDoc = function(mdown){


### PR DESCRIPTION
Now you can override markdown parser by passing parsingFunction parameter