### PR TITLE
Make parser.js compatible with showdown >= 1.3.0

### DIFF
--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -8,7 +8,7 @@ var Parser = function(config) {
         this.parseMdown = config.parsingFunction;
     } else {
         var converter = new showdown.Converter();
-        this.parseMdown = converter.makeHtml;
+        this.parseMdown = converter.makeHtml.bind(converter);
     }
 }
 


### PR DESCRIPTION
Parser reassigns showdown's makeHtml and leaves "this" reference hanging. This binds the converter object to makeHtml method fixing the issue.

Related to #50 and https://github.com/showdownjs/showdown/issues/213