### PR TITLE
Fixed working with relative paths on Windows

### DIFF
--- a/src/js/pathProcessor.js
+++ b/src/js/pathProcessor.js
@@ -36,7 +36,7 @@ exports.getFilesPaths = function(o){
         fname = normalizePath(fname);
 
         var ext = path.extname(fname),
-            fileDir = path.dirname(fname).replace(o.inputDir, '');
+            fileDir = path.relative(o.inputDir, path.dirname(fname));
 
         paths.push({
             input : fname,

--- a/src/js/writter.js
+++ b/src/js/writter.js
@@ -83,7 +83,7 @@ Writter.prototype.processDoc = function(){
 
         pathProcessor.processFile(fileInfo, function(content){
             var parseResult = self.parser.parseDoc(content, self.config.headingLevel),
-                fileName = fileInfo.output.replace(self.config.outputDir, '').replace(/^[\/\\]/, ''),
+                fileName = path.relative(self.config.outputDir, fileInfo.output).replace(/^[\/\\]/, ''),
                 moduleName = self.config.mapTocName? self.config.mapTocName(fileName, parseResult.toc, parseResult.title) : fileName.replace('.html', '');
 
             toc.push({


### PR DESCRIPTION
Some path operations was implemented through 'replace' function which is non platform-agnostic. This commit fixes some of this with node path functions.