### PR TITLE
Customizable TOC title and custom highlighter support

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -92,6 +92,9 @@ is `Filename : WhatIsInbaseTitle`.
 
 `baseTitle: 'mdocs title tag'`
 
+#### Table of content string
+You can replace the "Table of contents" string in outputted HTML with the `tocString` option.
+
 ### Advanced settings (Optional)
 
 #### Custom Templates

--- a/README.mdown
+++ b/README.mdown
@@ -95,6 +95,10 @@ is `Filename : WhatIsInbaseTitle`.
 #### Table of content string
 You can replace the "Table of contents" string in outputted HTML with the `tocString` option.
 
+#### Table of content wrapper class
+By default the table of content is wrapped in a div of `mdoc-toc` class. You can override this with the `config.tocClass`
+option.
+
 ### Advanced settings (Optional)
 
 #### Custom Templates

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -109,13 +109,13 @@ Parser.prototype.parseContent = function(mdown, toc){
         pre = mdown.substring(0, tocIndex),
         post = mdown.substring(tocIndex),
         tocString = this.config.tocString ? this.config.tocString : 'Table of Contents'
-        tocContent = `${this.getHeaderHashes()} ${this.config.tocString} <a href="#toc" name="toc" class="deep-link">#</a>\n\n`;
+        tocContent = `${this.getHeaderHashes()} ${this.config.tocString} <a href="#toc" name="toc" class="deep-link">#</a>`;
 
     toc.forEach(function(val, i){
         tocContent += ' - ['+ val.name +'](#'+ val.href +')\n';
     });
 
-    return this.parseMdown( pre + tocContent + post );
+  return this.parseMdown( `${pre}${tocContent}\n${post}` );
 }
 
 

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -109,13 +109,14 @@ Parser.prototype.parseContent = function(mdown, toc){
         pre = mdown.substring(0, tocIndex),
         post = mdown.substring(tocIndex),
         tocString = this.config.tocString ? this.config.tocString : 'Table of Contents'
-        tocContent = `${this.getHeaderHashes()} ${this.config.tocString} <a href="#toc" name="toc" class="deep-link">#</a>`;
+        tocContent = `${this.getHeaderHashes()} ${this.config.tocString} <a href="#toc" name="toc" class="deep-link">#</a>\n\n`;
 
     toc.forEach(function(val, i){
         tocContent += ' - ['+ val.name +'](#'+ val.href +')\n';
     });
 
-  return this.parseMdown( `${pre}${tocContent}\n${post}` );
+    const tocClass=this.config.tocClass ? this.config.tocClass : 'mdoc-toc';
+    return this.parseMdown( `${pre}<div class="${tocClass}">${this.parseMdown(tocContent)}</div>\n\n${post}` );
 }
 
 

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -32,7 +32,12 @@ Parser.prototype.wrapCode = function(str, p1, p2){
 Parser.prototype.convertCodeBlocks = function(mdown){
     // showdown have issues with github style code blocks..
     var re = /^```\s*(\w+)\s*$([\s\S]*?)^```$/gm;
-    return mdown.replace(re, this.wrapCode);
+    console.log(this.config.parsingFunction);
+    if(!this.config.parsingFunction){
+      console.log('no parsing !');
+      return mdown.replace(re, this.wrapCode);
+    }
+    return mdown
 }
 
 Parser.prototype.normalizeLineBreaks = function(str, lineEnd) {

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -108,7 +108,8 @@ Parser.prototype.parseContent = function(mdown, toc){
     var tocIndex = mdown.search( new RegExp('^'+ this.getHeaderHashes() +'[^#]+', 'm') ), //first header
         pre = mdown.substring(0, tocIndex),
         post = mdown.substring(tocIndex),
-        tocContent = this.getHeaderHashes() +' Table of Contents <a href="#toc" name="toc" class="deep-link">#</a>\n\n';
+        tocString = this.config.tocString ? this.config.tocString : 'Table of Contents'
+        tocContent = `${this.getHeaderHashes()} ${this.config.tocString} <a href="#toc" name="toc" class="deep-link">#</a>\n\n`;
 
     toc.forEach(function(val, i){
         tocContent += ' - ['+ val.name +'](#'+ val.href +')\n';

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -32,9 +32,7 @@ Parser.prototype.wrapCode = function(str, p1, p2){
 Parser.prototype.convertCodeBlocks = function(mdown){
     // showdown have issues with github style code blocks..
     var re = /^```\s*(\w+)\s*$([\s\S]*?)^```$/gm;
-    console.log(this.config.parsingFunction);
     if(!this.config.parsingFunction){
-      console.log('no parsing !');
       return mdown.replace(re, this.wrapCode);
     }
     return mdown

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -97,10 +97,12 @@ Parser.prototype.parseContent = function(mdown, toc){
     // add deep-links
 
     var i = 0, cur;
+    const deepLinkSymbol = this.config.deepLinkSymbol ? this.config.deepLinkSymbol : '#';
+    const tocString = this.config.tocString ? this.config.tocString : 'Table of Contents'
 
     mdown = mdown.replace(this.getHeaderRegExp(), function(str){
         cur = toc[i++];
-        return str +' <a href="#'+ cur.href +'" id="'+ cur.href +'" class="deep-link">#</a>';
+        return `${str} <a href="#${cur.href}" id="${cur.href}" class="deep-link">${deepLinkSymbol}</a>`;
     });
 
     // generate TOC
@@ -108,8 +110,7 @@ Parser.prototype.parseContent = function(mdown, toc){
     var tocIndex = mdown.search( new RegExp('^'+ this.getHeaderHashes() +'[^#]+', 'm') ), //first header
         pre = mdown.substring(0, tocIndex),
         post = mdown.substring(tocIndex),
-        tocString = this.config.tocString ? this.config.tocString : 'Table of Contents'
-        tocContent = `${this.getHeaderHashes()} ${this.config.tocString} <a href="#toc" name="toc" class="deep-link">#</a>\n\n`;
+        tocContent = `${this.getHeaderHashes()} ${this.config.tocString} <a href="#toc" name="toc" class="deep-link">${deepLinkSymbol}</a>\n\n`;
 
     toc.forEach(function(val, i){
         tocContent += ' - ['+ val.name +'](#'+ val.href +')\n';


### PR DESCRIPTION
I added the possibility to use a custom string for the "Table of content", and updated block highlighting : mdoc won't parse code blocks anymore when a custom parser is given.